### PR TITLE
post width alterations

### DIFF
--- a/WowsKarma.Web/Pages/Posts/PostsIndex.razor
+++ b/WowsKarma.Web/Pages/Posts/PostsIndex.razor
@@ -35,7 +35,7 @@
 							<NavLink href=@($"/player/{post.PlayerId},{post.PlayerUsername}")>@post.PlayerUsername</NavLink>
 						</p>
 
-						<div class="card border-@GetPostBorderColor(post.Flairs)" style="max-width: 20rem;">
+						<div class="card border-@GetPostBorderColor(post.Flairs)" style="width: 20rem; max-width: calc(100vw - 2rem);">
 							<h5 class="card-header">@post.Title</h5>
 
 							<div class="card-body">

--- a/WowsKarma.Web/Pages/Posts/PostsReceived.razor
+++ b/WowsKarma.Web/Pages/Posts/PostsReceived.razor
@@ -46,7 +46,7 @@
 		<div class="row">
 			@foreach (PlayerPostDTO post in PlayerPosts)
 			{
-				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="max-width: 20rem;">
+				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="width: 20rem; max-width: calc(100vw - 20rem);">
 					<h5 class="card-header">@post.Title</h5>
 					<div class="card-body">
 						<p class="card-text" style="white-space: pre-wrap;">@post.Content</p>

--- a/WowsKarma.Web/Pages/Posts/PostsReceived.razor
+++ b/WowsKarma.Web/Pages/Posts/PostsReceived.razor
@@ -46,7 +46,7 @@
 		<div class="row">
 			@foreach (PlayerPostDTO post in PlayerPosts)
 			{
-				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="width: 20rem; max-width: calc(100vw - 20rem);">
+				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="width: 20rem; max-width: calc(100vw - 2rem);">
 					<h5 class="card-header">@post.Title</h5>
 					<div class="card-body">
 						<p class="card-text" style="white-space: pre-wrap;">@post.Content</p>

--- a/WowsKarma.Web/Pages/Posts/PostsSent.razor
+++ b/WowsKarma.Web/Pages/Posts/PostsSent.razor
@@ -17,7 +17,7 @@
 		<div class="row">
 			@foreach (PlayerPostDTO post in PlayerPosts)
 			{
-				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="max-width: 20rem;">
+				<div class="card border-@GetPostBorderColor(post.Flairs) my-3 mx-3" style="width: 20rem; max-width: calc(100vw - 2rem);">
 					<h5 class="card-header">@post.Title</h5>
 					<div class="card-body">
 						<p class="card-text" style="white-space: pre-wrap;">@post.Content</p>


### PR DESCRIPTION
make posts prefer full width unless page is too thin, in which case they are page width minus margins
also fixes posts with links overflowing in width (previously posts with links or other long words would stop shrinking, now words will wrap rather than expand the post's width)