### PR TITLE
Add inline css `text-break` to replay chat message text

### DIFF
--- a/WowsKarma.Api/Services/Replays/ReplaysIngestService.cs
+++ b/WowsKarma.Api/Services/Replays/ReplaysIngestService.cs
@@ -46,7 +46,7 @@ public class ReplaysIngestService
 			ChatMessages = replay.ChatMessages.Adapt<IEnumerable<ReplayChatMessageDTO>>()
 				.Select(m => m with { Username = replay.Players.FirstOrDefault(p => p.AccountId == m.PlayerId).Name }),
 			Players = replay.Players.Adapt<IEnumerable<ReplayPlayerDTO>>(),
-			DownloadUri = (await GenerateReplayDownloadLinkAsync(id)).ToString(),
+			DownloadUri = null //(await GenerateReplayDownloadLinkAsync(id)).ToString(),
 		};
 	}
 

--- a/WowsKarma.Web/Pages/Replays/ReplayChat.razor
+++ b/WowsKarma.Web/Pages/Replays/ReplayChat.razor
@@ -39,7 +39,7 @@
                 <small class="@GetChannelColor(channel)">@channel.GetDisplayString()</small>
             </div>
 
-            <p class="mb-1">@msg.MessageContent</p>
+            <p class="mb-1 text-break">@msg.MessageContent</p>
         </a>
     }
 


### PR DESCRIPTION
This prevents the chat replay text from going out of container as the `.text-break` css class forces a word break - https://getbootstrap.com/docs/4.3/utilities/text/#word-break; so this should provide the fix!

Wasn't able to test by running the project directly (though did get both projects up and running), so I used a random post from the Posts page. I edited the paragraph html tag for the chat text directly. I've attached the before and after screenshots.

**Before**:
![Screen Shot 2022-06-01 at 4 45 54 AM](https://user-images.githubusercontent.com/13528490/171370813-5b7b842e-67a8-4c6d-a505-a3d4026c72e7.png)

**After**:
![Screen Shot 2022-06-01 at 4 45 28 AM](https://user-images.githubusercontent.com/13528490/171370882-71e8a331-6d29-46d8-8920-f3362750a07a.png)
