### PR TITLE
Change Sass Builder NuGet package to `AspNetCore.SassCompiler`

### DIFF
--- a/WowsKarma.Web/WowsKarma.Web.csproj
+++ b/WowsKarma.Web/WowsKarma.Web.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNet.Security.OpenId" Version="6.0.0" />
-    <PackageReference Include="LibSassBuilder" Version="2.0.1" />
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.52.1.2" />
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web.Extensions" Version="5.0.0-preview9.20513.1" />
@@ -62,6 +62,7 @@
 
   <ItemGroup>
     <Content Remove="compilerconfig.json" />
+    <Content Remove="sasscompiler.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -70,6 +71,7 @@
 
   <ItemGroup>
     <None Include="compilerconfig.json" />
+    <None Include="sasscompiler.json" />
     <None Update="Pages\Clans\ClanMetricDisplay.razor.scss">
       <DependentUpon>ClanMetricDisplay.razor</DependentUpon>
     </None>

--- a/WowsKarma.Web/sasscompiler.json
+++ b/WowsKarma.Web/sasscompiler.json
@@ -1,0 +1,12 @@
+{
+  "SourceFolder": "wwwroot/css",
+  "TargetFolder": "wwwroot/css",
+  "Arguments": "--style=compressed --no-source-map",
+  "GenerateScopedCss": true,
+  "ScopedCssFolders": [
+    "Views",
+    "Pages",
+    "Shared",
+    "Components"
+  ]
+}


### PR DESCRIPTION
This provides a working solution for Apple Silicon machines to build the Web project.

The previous NuGet package: `LibSassBuilder` has an open issue for support of M1 Macs running into issues with the MSBuild Target complaining about not being able to run the command to compile the Sass files - https://github.com/johan-v-r/LibSassBuilder/issues/42

Not quite sure if the `compilerconfig.json` files are still needed, so I left them as is.