### PR TITLE
Ease of setup changes

### DIFF
--- a/WowsKarma.Api/Program.cs
+++ b/WowsKarma.Api/Program.cs
@@ -65,7 +65,8 @@ namespace WowsKarma.Api
 					{
 						config.SetBasePath(Directory.GetCurrentDirectory());
 						config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-							  .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+							  .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+							  .AddUserSecrets<Program>(optional: true, reloadOnChange: true);
 						config.AddEnvironmentVariables();
 						config.AddCommandLine(args);
 					});

--- a/WowsKarma.Api/appsettings.Development.json
+++ b/WowsKarma.Api/appsettings.Development.json
@@ -4,7 +4,11 @@
       "Default": "Debug"
     }
   },
-
+  "ConnectionStrings": {
+    "ApiDbConnectionString": {
+      "EU": "FIXME : Placeholder value"
+    }
+  },
   "API": {
     "CurrentRegion": "EU",
     "EU": {

--- a/WowsKarma.Api/appsettings.Development.json
+++ b/WowsKarma.Api/appsettings.Development.json
@@ -6,6 +6,7 @@
   },
 
   "API": {
+    "CurrentRegion": "EU",
     "EU": {
       "CookieName": "Auth_EU",
       "CookieDomain": "localhost",

--- a/WowsKarma.Web/Program.cs
+++ b/WowsKarma.Web/Program.cs
@@ -54,7 +54,8 @@ namespace WowsKarma.Web
 					{
 						config.SetBasePath(Directory.GetCurrentDirectory());
 						config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-							  .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+							  .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+							  .AddUserSecrets<Program>(optional: true, reloadOnChange: true);
 						config.AddEnvironmentVariables();
 						config.AddCommandLine(args);
 					});

--- a/WowsKarma.Web/Startup.cs
+++ b/WowsKarma.Web/Startup.cs
@@ -89,7 +89,6 @@ namespace WowsKarma.Web
 				.AddScheme<AuthenticationSchemeOptions, ApiTokenAuthenticationHandler>(ApiTokenAuthenticationHandler.AuthenticationScheme, "API Token", _ => { });
 
 			services.AddAuthorizationCore();
-			services.AddHttpContextAccessor();
 
 			services.AddResponseCompression(opts =>
 			{

--- a/WowsKarma.Web/WowsKarma.Web.csproj
+++ b/WowsKarma.Web/WowsKarma.Web.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="Mapster" Version="7.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web.Extensions" Version="5.0.0-preview9.20513.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="6.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.3" />

--- a/WowsKarma.Web/appsettings.Development.json
+++ b/WowsKarma.Web/appsettings.Development.json
@@ -10,6 +10,7 @@
   "DetailedErrors": true,
 
   "Api": {
+    "CurrentRegion": "EU",
     "EU": {
       "WebDomain": "https://localhost:5001",
       "CookieName": "Auth_EU",


### PR DESCRIPTION
Some small ease of use / project setup changes. Arguably, user secrets, removal of duplicate service, and Razor.RuntimeCompilation could be a separate PR as they are more core functionality changes, but decided to bundle them here. If needed/wanted I can cherry-pick them to a diff PR.

Adding properties / structures to the `appsettings.json` files makes it a bit easier to get up and running after cloning the project, as most of the required keys are there, either to be changed or filled in, rather than trying to run and tracing through the exception to figure out what parts of the configuration needed to be addressed (which still may happen but slightly less painful).