### PR TITLE
Change `ComponentBaseAuth.cs` component to get AuthenticationState from CascadingParameter

### DIFF
--- a/WowsKarma.Web/Shared/Components/ComponentBaseAuth.cs
+++ b/WowsKarma.Web/Shared/Components/ComponentBaseAuth.cs
@@ -13,7 +13,7 @@ namespace WowsKarma.Web.Shared.Components
 	public abstract class ComponentBaseAuth : ComponentBase
 	{
 		[Inject] protected IHttpContextAccessor HttpContextAccessor { get; set; }
-		[Inject] protected AuthenticationStateProvider AuthenticationStateProvider { get; set; }
+		[CascadingParameter] public Task<AuthenticationState> AuthStateTask { get; set; }
 
 		protected AccountListingDTO CurrentUser { get; private set; }
 		protected ClaimsPrincipal ClaimsPrincipal { get; private set; }
@@ -23,7 +23,7 @@ namespace WowsKarma.Web.Shared.Components
 		{
 			await base.OnInitializedAsync();
 
-			AuthenticationState authenticationState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+			AuthenticationState authenticationState = await AuthStateTask;
 			ClaimsPrincipal = authenticationState.User;
 			CurrentUser = authenticationState.User.ToAccountListing();
 			CurrentToken = HttpContextAccessor?.HttpContext?.Request?.Cookies[ApiTokenAuthenticationHandler.CookieName];


### PR DESCRIPTION
Injecting the AuthenticationStateProvider itself does not receive AuthenticationState change notifications.

- This PR can be ignored if using the `AuthenticationStateProvider` is intended as changes for the AuthenticationState will be handled on navigation to component or reload of page.